### PR TITLE
fix Netflix API endpoint change

### DIFF
--- a/resources/get.py
+++ b/resources/get.py
@@ -213,7 +213,7 @@ def series_info(series_id):
         content = generic_utility.decode(file_handler.read())
         file_handler.close()
     if not content:
-        url = generic_utility.series_url % (generic_utility.get_setting('api_url'), series_id)
+        url = generic_utility.series_url % (generic_utility.api_url, generic_utility.endpoints()['/metadata'], series_id)
         content = connect.load_netflix_site(url)
         file_handler = xbmcvfs.File(cache_file, 'wb')
         file_handler.write(generic_utility.encode(content))
@@ -282,7 +282,7 @@ def genre_info(video_type):
 
 
 def viewing_activity_info():
-    content = connect.load_netflix_site(generic_utility.activity_url % (generic_utility.get_setting('api_url'),
+    content = connect.load_netflix_site(generic_utility.activity_url % (generic_utility.api_url, generic_utility.endpoints()['/viewingactivity'],
                                                                         generic_utility.get_setting(
                                                                                 'authorization_url')))
     return content

--- a/resources/login.py
+++ b/resources/login.py
@@ -45,10 +45,9 @@ def login():
                      'authURL': generic_utility.get_setting('authorization_url'),
                      'email': generic_utility.get_setting('username'),
                      'password':  generic_utility.get_setting('password'), 
-                     'RememberMeCheckbox': 'true',
-                     'RememberMe': 'on',
-                     'flow': 'websiteSignup',
-                     'mode': 'login',
+                     'rememberMe': 'true',
+                     'flow': 'websiteSignUp',
+                     'mode': 'loginPassword',
                      'action': 'loginAction',
                      'withFields': 'email,password,rememberMe,nextPage',
                      'nextPage': ''}
@@ -88,18 +87,18 @@ def login():
 
 
 def parse_data_set_cookies(content):
-    parse_api_url(content)
+    parse_endpoints(content)
     connect.set_chrome_netflix_cookies()
 
 
 
 
-def parse_api_url(content):
-    match = re.compile('"apiUrl":"(.+?)",', re.UNICODE).findall(content)
+def parse_endpoints(content):
+    match = re.compile('"endpointIdentifiers":({.+?}),', re.UNICODE).findall(content)
     if len(match) > 0:
-        generic_utility.set_setting('api_url', match[0])
+        generic_utility.set_setting('endpoints', match[0])
     else:
-        generic_utility.error('Cannot find apiUrl! Source: ' + content)
+        generic_utility.error('Cannot find api endpoints! Source: ' + content)
 
 
 def choose_profile():
@@ -125,7 +124,7 @@ class CannotRefreshDataException(Exception):
 
 def refresh_data():
     content = connect.load_netflix_site('https://www.netflix.com/browse')
-    parse_api_url(content)
+    parse_endpoints(content)
 
     profl = generic_utility.get_setting('selected_profile')
     if not profl:

--- a/resources/path_evaluator/__init__.py
+++ b/resources/path_evaluator/__init__.py
@@ -12,9 +12,9 @@ def req_path(*paths):
     from resources import connect
 
     auth_url = generic_utility.auth_url()
-    api_url = generic_utility.api_url()
+    endpoints = generic_utility.endpoints()
 
-    if not auth_url or not api_url:
+    if not auth_url or not endpoints:
         connect.do_login()
 
     post = '{"paths":['
@@ -23,7 +23,7 @@ def req_path(*paths):
     post = post[:-1]
     post += '],"authURL":"%s"}' % auth_url
 
-    content = connect.load_netflix_site('%s/pathEvaluator?materialize=true&model=harris' % api_url, post)
+    content = connect.load_netflix_site(generic_utility.evaluator_url % (generic_utility.api_url, endpoints['/pathEvaluator']), post)
     jsn = json.loads(content)
     if 'error' in jsn:
         err = jsn['error']

--- a/resources/utility/generic_utility.py
+++ b/resources/utility/generic_utility.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import HTMLParser
+import json
 import os
 import sys
 import urllib
@@ -25,13 +26,12 @@ if test == False:
 # urls for netflix
 main_url = 'https://www.netflix.com/'
 kids_url = 'https://www.netflix.com/Kids'
-evaluator_url = '%s/pathEvaluator?materialize=true&model=harris'
-profile_switch_url = '%s/profiles/switch?'
+api_url = 'https://www.netflix.com/api/shakti'
+evaluator_url = '%s/pathEvaluator/%s?materialize=true&model=harris'
+profile_switch_url = '%s/profiles/switch/%s?'
 profile_url = 'http://api-global.netflix.com/desktop/account/profiles?version=2&withCredentials=true'
-picture_url = 'https://image.tmdb.org/t/p/original'
-series_url = '%s/metadata?movieid=%s&imageFormat=jpg'
-tmdb_url = 'https://api.themoviedb.org/3/search/%s?api_key=%s&query=%s&language=de'
-activity_url = '%s/viewingactivity?_retry=0&authURL=%s'
+series_url = '%s/metadata/%s?movieid=%s&imageFormat=jpg'
+activity_url = '%s/viewingactivity/%s?_retry=0&authURL=%s'
 
 # post data information
 
@@ -104,17 +104,17 @@ def create_pathname(path, item):
 
 
 def evaluator():
-    return evaluator_url % api_url()
+    return evaluator_url % (api_url, endpoints()['/pathEvaluator'])
 
 
-def api_url():
-    return get_setting('api_url')
+def endpoints():
+    return json.loads(get_setting('endpoints'))
 
 def auth_url():
     return get_setting('authorization_url')
 
 def profile_switch():
-    return profile_switch_url % api_url()
+    return profile_switch_url % (api_url, endpoints()['/profiles/switch'])
 
 def error(message):
     if test == False:


### PR DESCRIPTION
The Netflix API is no longer accessed under a specific /shakti[number]
resource, but now under just /shakti with a specific endpoint string
added to the end of each API call. These changes store the dictionary of
endpoint suffixes and uses them when building the URLs to API calls.